### PR TITLE
fix an IndexOutOfBoundsException bug in slow network

### DIFF
--- a/Android/app/src/main/java/cn/leancloud/leanstoragegettingstarted/MainActivity.java
+++ b/Android/app/src/main/java/cn/leancloud/leanstoragegettingstarted/MainActivity.java
@@ -73,7 +73,6 @@ public class MainActivity extends AppCompatActivity {
   }
 
   private void initData() {
-    mList.clear();
     AVQuery<AVObject> avQuery = new AVQuery<>("Product");
     avQuery.orderByDescending("createdAt");
     avQuery.include("owner");
@@ -81,6 +80,7 @@ public class MainActivity extends AppCompatActivity {
       @Override
       public void done(List<AVObject> list, AVException e) {
         if (e == null) {
+          mList.clear();
           mList.addAll(list);
           mRecyclerAdapter.notifyDataSetChanged();
         } else {


### PR DESCRIPTION
mList.clear()之后, 因为没有调用notifyDataSetChanged(), 这个时候可以点击RecyclerView里的item, 但是如果网络比较慢, findInBackground()还没有完成的话, 这个时候Adapter里面对mList.get()调用就会出现IndexOutOfBoundsException